### PR TITLE
Remove iOS 7 -didRotateFromInterfaceOrientation implementation

### DIFF
--- a/NIMKit/NIMKit/Classes/Sections/Team/NIMAdvancedTeamCardViewController.m
+++ b/NIMKit/NIMKit/Classes/Sections/Team/NIMAdvancedTeamCardViewController.m
@@ -1121,14 +1121,6 @@
     }
 }
 
-#pragma mark - 旋转处理 (iOS7)
-
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
-{
-    NSIndexPath *reloadIndexPath = [NSIndexPath indexPathForRow:0 inSection:0];
-    [self.tableView reloadRowsAtIndexPaths:@[reloadIndexPath] withRowAnimation:UITableViewRowAnimationNone];
-}
-
 #pragma mark - 旋转处理 (iOS8 or above)
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator


### PR DESCRIPTION
To fix warning:

```
Sections/Team/NIMAdvancedTeamCardViewController.m:1126:1: Implementing deprecated method
```
