### PR TITLE
fix build error "Include of non-modular header inside framework module 'NIMKit.YYAnimatedImageView_iOS14'"

### DIFF
--- a/NIMKit/NIMKit/Classes/Category/YYAnimatedImageView+iOS14.h
+++ b/NIMKit/NIMKit/Classes/Category/YYAnimatedImageView+iOS14.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 NetEase. All rights reserved.
 //  修复YYAnimatedImageView在ios14上不显示图片的问题
 
-#import "YYAnimatedImageView.h"
+#import <YYImage/YYAnimatedImageView.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/NIMKit/NIMKit/Classes/NIMKit.h
+++ b/NIMKit/NIMKit/Classes/NIMKit.h
@@ -156,7 +156,7 @@ FOUNDATION_EXPORT const unsigned char NIMKitVersionString[];
 /**
  *  群信息变更通知接口
  *
- *  @param teamIds 群 id 集合
+ *  @param teamId 群 id 集合
  */
 - (void)notifyTeamInfoChanged:(NSString *)teamId type:(NIMKitTeamType)type;
 
@@ -164,7 +164,7 @@ FOUNDATION_EXPORT const unsigned char NIMKitVersionString[];
 /**
  *  群成员变更通知接口
  *
- *  @param teamIds 群id
+ *  @param teamId 群id
  */
 - (void)notifyTeamMemebersChanged:(NSString *)teamId type:(NIMKitTeamType)type;
 

--- a/NIMKit/NIMKit/Classes/Sections/Session/View/NIMCollectionViewLeftAlignedLayout.h
+++ b/NIMKit/NIMKit/Classes/Sections/Session/View/NIMCollectionViewLeftAlignedLayout.h
@@ -25,16 +25,8 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "UICollectionViewLeftAlignedLayout.h"
 
 @interface NIMCollectionViewLeftAlignedLayout : UICollectionViewFlowLayout
-
-@end
-
-/**
- *  Just a convenience protocol to keep things consistent.
- *  Someone could find it confusing for a delegate object to conform to UICollectionViewDelegateFlowLayout
- *  while using NIMCollectionViewLeftAlignedLayout.
- */
-@protocol UICollectionViewDelegateLeftAlignedLayout <UICollectionViewDelegateFlowLayout>
 
 @end

--- a/NIMKit/NIMKit/Classes/Sections/Session/ViewController/NIMSessionViewController.h
+++ b/NIMKit/NIMKit/Classes/Sections/Session/ViewController/NIMSessionViewController.h
@@ -125,7 +125,7 @@
  *  异步发送消息
  *
  *  @param message 消息
- *  @param 接口调用完成的回调，通常是所有本地工作完成，准备发送时回调
+ *                 接口调用完成的回调，通常是所有本地工作完成，准备发送时回调
  *  @param completion 完成回调
  */
 - (void)sendMessage:(NIMMessage *)message completion:(void(^)(NSError * err))completion;


### PR DESCRIPTION
- fix build error "Include of non-modular header inside framework module 'NIMKit.YYAnimatedImageView_iOS14'"
- fix document warning
- fix duplicate definition warning